### PR TITLE
feat: introduce use of multiple validator api endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,19 +7,20 @@ import (
 )
 
 type Config struct {
-	AvalancheAPI          string `json:"avalanche_api"`
-	AggregatorURL         string `json:"aggregator_url"`
-	GraphQLEndpoint       string `json:"graphql_endpoint"`
-	SigningSubnetID       string `json:"signing_subnet_id"`
-	SourceChainId         string `json:"source_chain_id"`
-	QuorumPercentage      int    `json:"quorum_percentage"`
-	BeamRPC               string `json:"beam_rpc"`
-	StakingManagerAddress string `json:"contract_address"`
-	WarpMessengerAddress  string `json:"warp_messenger_address"`
-	PrivateKey            string `json:"private_key"`
-	LogLevel              string `json:"log_level"`
-	NetworkID             int    `json:"network_id"`
-	DatabaseURL           string `json:"database_url"`
+	AvalancheAPI          string   `json:"avalanche_api"`
+	AvalancheAPIList      []string `json:"avalanche_api_list"`
+	AggregatorURL         string   `json:"aggregator_url"`
+	GraphQLEndpoint       string   `json:"graphql_endpoint"`
+	SigningSubnetID       string   `json:"signing_subnet_id"`
+	SourceChainId         string   `json:"source_chain_id"`
+	QuorumPercentage      int      `json:"quorum_percentage"`
+	BeamRPC               string   `json:"beam_rpc"`
+	StakingManagerAddress string   `json:"contract_address"`
+	WarpMessengerAddress  string   `json:"warp_messenger_address"`
+	PrivateKey            string   `json:"private_key"`
+	LogLevel              string   `json:"log_level"`
+	NetworkID             int      `json:"network_id"`
+	DatabaseURL           string   `json:"database_url"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"log"
 	"math"
-	"sort"
 	"time"
 
 	"uptime-service/aggregator"


### PR DESCRIPTION
- query all api endpoints for their PoV on validators' uptimes and store it in a map
- sort it and first use the highest value for signature request
-- if it succeeds, increase it just like how it does right now until it fails (and store the last uptime value accepted)
-- if it fails use the second highest and increase it until it fails (and store the last uptime value accepted)
-- continue this loop until the last api endpoint's value is exhausted
- after which the lowest uptime value from map is decreased until a signature is accepted, or the uptimeSeconds hits 0